### PR TITLE
Refrigerator: fix crash on list-form API, add ContactSensor + temps

### DIFF
--- a/drivers/thinq_connect_refrigerator.groovy
+++ b/drivers/thinq_connect_refrigerator.groovy
@@ -4,6 +4,23 @@
  *  Copyright 2025
  *
  *  Uses official LG ThinQ Connect API
+ *
+ *  Community bug-fixes and extensions (2026-04-18):
+ *    Fix A — doorStatus list parsing: LG API returns doorStatus as a list of
+ *             location objects, not a flat map. Prior code threw ClassCastException
+ *             before any attributes could populate. Now finds MAIN location by name.
+ *    Fix B — ContactSensor capability added for rule-engine door-open/close triggers.
+ *    Fix C — temperatureInUnits list parsing: emits per-location fridge/freezer
+ *             attributes and preserves backward-compat flat attrs from FRIDGE location.
+ *    Fix D — freshAirFilterReplaceNeeded derived boolean attribute.
+ *    Fix E — Per-location set-temperature commands (setFridgeTargetTemperatureC/F,
+ *             setFreezerTargetTemperatureC/F). Existing setTargetTemperatureC/F
+ *             preserved as FRIDGE aliases for backward compatibility.
+ *    Fix F — data unwrap: tolerate both List-wrapped and flat-Map API responses.
+ *    Fix G — Robustness NITs: doorStatus falls back to first entry when no MAIN
+ *             location found; freshAirFilterReplaceNeeded uses contains("REPLACE")
+ *             for future variant tolerance; unknown temperatureInUnits locations
+ *             emit a debug log instead of silently skipping.
  */
 
 import groovy.transform.Field
@@ -18,11 +35,20 @@ metadata {
         capability "Sensor"
         capability "Initialize"
         capability "Refresh"
+        capability "ContactSensor"  // Fix B: door open/close for rule-engine triggers
 
         attribute "doorState", "string"
+        attribute "contact", "enum", ["open", "closed"]  // Fix B: ContactSensor standard attr
         attribute "temperatureUnit", "string"
         attribute "targetTemperatureC", "number"
         attribute "targetTemperatureF", "number"
+        // Fix C: per-location temperature attributes
+        attribute "fridgeTargetTemperatureC", "number"
+        attribute "fridgeTargetTemperatureF", "number"
+        attribute "fridgeTemperatureUnit", "string"
+        attribute "freezerTargetTemperatureC", "number"
+        attribute "freezerTargetTemperatureF", "number"
+        attribute "freezerTemperatureUnit", "string"
         attribute "powerSaveEnabled", "string"
         attribute "ecoFriendlyMode", "string"
         attribute "sabbathMode", "string"
@@ -30,16 +56,23 @@ metadata {
         attribute "expressMode", "string"
         attribute "expressFridge", "string"
         attribute "freshAirFilter", "string"
+        attribute "freshAirFilterReplaceNeeded", "enum", ["true", "false"]  // Fix D
         attribute "usedTime", "number"
         attribute "waterFilterInfoUnit", "string"
-        
+
         // Commands
-        command "setTargetTemperatureC", ["number"]
-        command "setTargetTemperatureF", ["number"]
+        command "setTargetTemperatureC", ["number"]   // alias for setFridgeTargetTemperatureC
+        command "setTargetTemperatureF", ["number"]   // alias for setFridgeTargetTemperatureF
+        command "setFridgeTargetTemperatureC", ["number"]   // Fix E
+        command "setFridgeTargetTemperatureF", ["number"]   // Fix E
+        command "setFreezerTargetTemperatureC", ["number"]  // Fix E
+        command "setFreezerTargetTemperatureF", ["number"]  // Fix E
         command "setRapidFreeze", ["string"]
         command "setExpressMode", ["string"]
         command "setExpressFridge", ["string"]
         command "setFreshAirFilter", ["string"]
+        // DIAGNOSTIC: dump raw API state to logs for driver development
+        command "dumpRawState"
     }
 
     preferences {
@@ -81,6 +114,48 @@ def refresh() {
     logger("debug", "refresh()")
     def status = parent.getDeviceState(getDeviceId())
     processStateData(status)
+}
+
+// DIAGNOSTIC: dump raw API responses to info-level logs for driver development.
+// Captures both the per-device profile (static schema) and current state (live values).
+def dumpRawState() {
+    log.info "==== DUMP RAW STATE BEGIN: ${device.displayName} ===="
+    try {
+        def deviceId = getDeviceId()
+        log.info "deviceId=${deviceId}"
+        try {
+            def profile = parent.getDeviceProfile(deviceId)
+            def profileJson = groovy.json.JsonOutput.toJson(profile)
+            // log in chunks to avoid truncation in Hubitat logs (typical cap ~1024 chars)
+            int chunkSize = 900
+            log.info "PROFILE length=${profileJson?.length() ?: 0}"
+            if (profileJson) {
+                for (int i = 0; i < profileJson.length(); i += chunkSize) {
+                    int end = Math.min(i + chunkSize, profileJson.length())
+                    log.info "PROFILE[${i}]: ${profileJson.substring(i, end)}"
+                }
+            }
+        } catch (e) {
+            log.warn "getDeviceProfile failed: ${e}"
+        }
+        try {
+            def state = parent.getDeviceState(deviceId)
+            def stateJson = groovy.json.JsonOutput.toJson(state)
+            int chunkSize = 900
+            log.info "STATE length=${stateJson?.length() ?: 0}"
+            if (stateJson) {
+                for (int i = 0; i < stateJson.length(); i += chunkSize) {
+                    int end = Math.min(i + chunkSize, stateJson.length())
+                    log.info "STATE[${i}]: ${stateJson.substring(i, end)}"
+                }
+            }
+        } catch (e) {
+            log.warn "getDeviceState failed: ${e}"
+        }
+    } catch (e) {
+        log.error "dumpRawState failed: ${e}"
+    }
+    log.info "==== DUMP RAW STATE END ===="
 }
 
 def mqttConnectUntilSuccessful() {
@@ -137,34 +212,65 @@ def mqttClientStatus(String message) {
 
 def processStateData(data) {
     logger("debug", "processStateData(${data})")
-    data = data[0]
+    // Fix F: some API call paths return a list wrapper (e.g. historical MQTT messages),
+    // others return a flat Map (e.g. getDeviceState for Refrigerator on LRMVS2806S).
+    // Handle both without throwing.
+    if (data instanceof List) {
+        if (data.size() == 0) return
+        data = data[0]
+    }
 
     if (!data) return
 
-    // Process door status
-    if (data.doorStatus?.doorState) {
-        def doorState = data.doorStatus.doorState
-        sendEvent(name: "doorState", value: doorState)
-        
+    // Fix A: doorStatus is a list of location objects, not a flat map.
+    // Fix G NIT 1: fall back to first entry if no MAIN location found (e.g. French-door
+    // models with only DOOR_IN_DOOR). Future enhancement: emit per-door attrs for all entries.
+    if (data.doorStatus instanceof List) {
+        def mainDoor = data.doorStatus.find { it.locationName == "MAIN" } ?: data.doorStatus[0]
+        if (mainDoor?.doorState) {
+            def doorStateVal = mainDoor.doorState
+            sendEvent(name: "doorState", value: doorStateVal)
+            sendEvent(name: "contact", value: doorStateVal == "OPEN" ? "open" : "closed")  // Fix B
+            if (logDescText) {
+                log.info "${device.displayName} DoorState: ${doorStateVal}"
+            }
+        }
+    } else if (data.doorStatus?.doorState) {
+        // Fallback: handle flat-map form (older firmware / other models)
+        def doorStateVal = data.doorStatus.doorState
+        sendEvent(name: "doorState", value: doorStateVal)
+        sendEvent(name: "contact", value: doorStateVal == "OPEN" ? "open" : "closed")  // Fix B
         if (logDescText) {
-            log.info "${device.displayName} DoorState: ${doorState}"
+            log.info "${device.displayName} DoorState: ${doorStateVal}"
         }
     }
 
-    // Process temperature information
-    if (data.temperatureInUnits) {
-        // Handle temperature unit
-        if (data.temperatureInUnits.unit) {
-            sendEvent(name: "temperatureUnit", value: data.temperatureInUnits.unit)
+    // Fix C: temperatureInUnits is a list of location objects, not a flat map.
+    // Emits per-location fridge/freezer attrs; also populates flat attrs from FRIDGE for
+    // backward compatibility with existing rules/dashboards.
+    if (data.temperatureInUnits instanceof List) {
+        data.temperatureInUnits.each { loc ->
+            def prefix = (loc.locationName == "FRIDGE") ? "fridge" :
+                         (loc.locationName == "FREEZER") ? "freezer" : null
+            if (prefix == null) {
+                logger("debug", "Unknown temperature location: ${loc.locationName}")
+                return
+            }
+            if (loc.targetTemperatureC != null) sendEvent(name: "${prefix}TargetTemperatureC", value: loc.targetTemperatureC)
+            if (loc.targetTemperatureF != null) sendEvent(name: "${prefix}TargetTemperatureF", value: loc.targetTemperatureF)
+            if (loc.unit != null) sendEvent(name: "${prefix}TemperatureUnit", value: loc.unit)
+            // Backward compat: flat attrs mirror FRIDGE location
+            if (prefix == "fridge") {
+                if (loc.targetTemperatureC != null) sendEvent(name: "targetTemperatureC", value: loc.targetTemperatureC)
+                if (loc.targetTemperatureF != null) sendEvent(name: "targetTemperatureF", value: loc.targetTemperatureF)
+                if (loc.unit != null) sendEvent(name: "temperatureUnit", value: loc.unit)
+            }
         }
-        
-        // Handle target temperatures
-        if (data.temperatureInUnits.targetTemperatureC != null) {
-            sendEvent(name: "targetTemperatureC", value: data.temperatureInUnits.targetTemperatureC)
-        }
-        if (data.temperatureInUnits.targetTemperatureF != null) {
-            sendEvent(name: "targetTemperatureF", value: data.temperatureInUnits.targetTemperatureF)
-        }
+    } else if (data.temperatureInUnits) {
+        // Fallback: flat-map form (older firmware / other models)
+        if (data.temperatureInUnits.unit) sendEvent(name: "temperatureUnit", value: data.temperatureInUnits.unit)
+        if (data.temperatureInUnits.targetTemperatureC != null) sendEvent(name: "targetTemperatureC", value: data.temperatureInUnits.targetTemperatureC)
+        if (data.temperatureInUnits.targetTemperatureF != null) sendEvent(name: "targetTemperatureF", value: data.temperatureInUnits.targetTemperatureF)
     }
 
     // Process power save
@@ -201,6 +307,10 @@ def processStateData(data) {
     if (data.refrigeration?.freshAirFilter) {
         def freshAirFilter = cleanEnumValue(data.refrigeration.freshAirFilter)
         sendEvent(name: "freshAirFilter", value: freshAirFilter)
+        // Fix D/G: REPLACE is a read-only status meaning "filter needs replacement".
+        // Use contains("REPLACE") to tolerate future variants like "REPLACE_NEEDED".
+        sendEvent(name: "freshAirFilterReplaceNeeded",
+                  value: (data.refrigeration.freshAirFilter?.toString()?.contains("REPLACE")) ? "true" : "false")
     }
 
     // Process water filter info
@@ -232,12 +342,53 @@ def setTargetTemperatureF(temperature) {
     def deviceId = getDeviceId()
     def command = [
         location: [
-            locationName: "FRIDGE"  // Default location, in a real implementation this might need to be configurable
+            locationName: "FRIDGE"  // Backward-compat alias for setFridgeTargetTemperatureF
         ],
         temperatureInUnits: [
             targetTemperatureF: temperature,
             unit: "F"
         ]
+    ]
+    parent.sendDeviceCommand(deviceId, command)
+}
+
+// Fix E: per-location temperature set commands
+def setFridgeTargetTemperatureC(temperature) {
+    logger("debug", "setFridgeTargetTemperatureC(${temperature})")
+    def deviceId = getDeviceId()
+    def command = [
+        location: [locationName: "FRIDGE"],
+        temperatureInUnits: [targetTemperatureC: temperature, unit: "C"]
+    ]
+    parent.sendDeviceCommand(deviceId, command)
+}
+
+def setFridgeTargetTemperatureF(temperature) {
+    logger("debug", "setFridgeTargetTemperatureF(${temperature})")
+    def deviceId = getDeviceId()
+    def command = [
+        location: [locationName: "FRIDGE"],
+        temperatureInUnits: [targetTemperatureF: temperature, unit: "F"]
+    ]
+    parent.sendDeviceCommand(deviceId, command)
+}
+
+def setFreezerTargetTemperatureC(temperature) {
+    logger("debug", "setFreezerTargetTemperatureC(${temperature})")
+    def deviceId = getDeviceId()
+    def command = [
+        location: [locationName: "FREEZER"],
+        temperatureInUnits: [targetTemperatureC: temperature, unit: "C"]
+    ]
+    parent.sendDeviceCommand(deviceId, command)
+}
+
+def setFreezerTargetTemperatureF(temperature) {
+    logger("debug", "setFreezerTargetTemperatureF(${temperature})")
+    def deviceId = getDeviceId()
+    def command = [
+        location: [locationName: "FREEZER"],
+        temperatureInUnits: [targetTemperatureF: temperature, unit: "F"]
     ]
     parent.sendDeviceCommand(deviceId, command)
 }


### PR DESCRIPTION
## Summary

Fixes a `ClassCastException` at line 140 of `processStateData` in `drivers/thinq_connect_refrigerator.groovy` that crashes the driver before any attribute can populate. Happens on LG fridges (including French-door LRMVS-class models) where the Connect API returns `doorStatus` and `temperatureInUnits` as **lists of per-location objects**, not flat maps. Current code assumes flat maps → crash.

Also adds several attributes and commands that were latent in the API but unexposed.

## Background / evidence

Raw `GET /devices/{id}/state` response from an LG LRMVS2806S-class French-door fridge:

```json
{
  "doorStatus": [{"doorState": "CLOSE", "locationName": "MAIN"}],
  "powerSave": {"powerSaveEnabled": true},
  "refrigeration": {"expressMode": false, "freshAirFilter": "REPLACE"},
  "sabbath": {"sabbathMode": false},
  "temperature": [
    {"locationName": "FRIDGE", "targetTemperature": 36, "unit": "F"},
    {"locationName": "FREEZER", "targetTemperature": 0, "unit": "F"}
  ],
  "temperatureInUnits": [
    {"locationName": "FRIDGE", "targetTemperatureF": 36, "unit": "F"},
    {"locationName": "FREEZER", "targetTemperatureF": 0, "unit": "F"}
  ],
  "waterFilterInfo": {"unit": "month", "usedTime": 6}
}
```

Note that `doorStatus` and `temperatureInUnits` are lists — each entry is a location. The existing driver code `data.doorStatus?.doorState` and `data.temperatureInUnits?.targetTemperatureF` silently treat the list as a map, which returns garbage; Hubitat's `sendEvent` then tries to coerce that garbage to Integer and throws `ClassCastException`.

This matches the schema documented in LG's official reference client ([pythinqconnect/devices/refrigerator.py](https://github.com/thinq-connect/pythinqconnect/blob/main/thinqconnect/devices/refrigerator.py)).

## Changes (single file: `drivers/thinq_connect_refrigerator.groovy`)

- **Fix A — doorStatus list parsing.** Detects list-form via `instanceof List`, finds the `MAIN` location, falls back to first entry for non-standard multi-door models. Flat-map fallback preserved for any model that still returns the old shape.
- **Fix B — `ContactSensor` capability added.** Emits `contact` derived from `doorState` (OPEN → open, else closed). Enables Hubitat rule-engine door-triggered automations.
- **Fix C — temperatureInUnits list parsing.** Iterates per-location entries; emits `fridgeTargetTemperatureC/F`, `fridgeTemperatureUnit`, `freezerTargetTemperatureC/F`, `freezerTemperatureUnit`. **Backward-compat:** FRIDGE values are also mirrored into the existing flat `targetTemperatureC/F` and `temperatureUnit` attributes, so any rules/dashboards referencing those continue to work. Unknown locations are debug-logged and skipped.
- **Fix D — `freshAirFilterReplaceNeeded` attribute.** Enum \`["true","false"]\` derived from `freshAirFilter` value via \`contains("REPLACE")\` (forward-compatible with potential variants). Surfaces a clean "filter needs replacement" signal for dashboards.
- **Fix E — Per-location set-temperature commands.** `setFridgeTargetTemperatureC/F` and `setFreezerTargetTemperatureC/F`. Existing `setTargetTemperatureC/F` retained as FRIDGE aliases.
- **Fix F — Tolerant `data` unwrap.** The pre-existing \`data = data[0]\` is now guarded by \`instanceof List\`, so `processStateData` handles both list-wrapped and flat-Map responses without throwing.
- **Diagnostic command `dumpRawState`** added — dumps raw profile + state JSON to info-level logs in chunks (to survive Hubitat's per-line truncation). Follows the same debugging-aid convention as `getDeviceProfile()` in the Air Conditioner/Cooktop/Oven drivers.

All pre-existing attributes and parsers (`rapidFreeze`, `expressFridge`, `ecoFriendlyMode`, `expressMode`, `powerSave`, `sabbath`, `waterFilterInfo`, base `freshAirFilter` enum) are **preserved unchanged**. No write-paths modified other than the addition of the new per-location set commands.

## Test plan

- [x] Verified live against an LRMVS2806S-class fridge: crash eliminated, 15 attributes populate correctly
- [x] Post-deploy error sweep: zero `ClassCastException` / `NullPointerException` with post-deploy timestamps
- [x] Backward compatibility traced through 18 scenarios by code review: flat-map doorStatus, flat-map temperatureInUnits, Celsius-only regions, models with `rapidFreeze`/`expressFridge`/`ecoFriendlyMode`, empty lists, unknown location names, unexpected types — all handled safely
- [ ] Field testing on a flat-map-returning fridge model would be welcome from any community user whose driver previously worked without this PR — should continue to work unchanged

## Notes for reviewers

- No `sendDeviceCommand` calls added to any read path — only user-invoked set* methods hit the write API (rate-limit safe)
- `dumpRawState` is user-invoked only, try/catch around both `getDeviceProfile` and `getDeviceState`, fails gracefully
- No changes to namespace or importUrl — remains `jonozzz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)